### PR TITLE
Change devices to simulators

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -41,7 +41,7 @@ suites:
     browserName: "safari"
     src:
       - "tests/*.test.js" # test files glob
-    devices:
+    simulators:
       - name: iPhone 12 Simulator
         platformName: iOS
         platformVersions:

--- a/examples/typescript/.sauce/config.yml
+++ b/examples/typescript/.sauce/config.yml
@@ -20,11 +20,6 @@ testcafe:
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:
-  - name: "Chrome using global mode setting" # Since the suite doesn't specify the `mode`, it'll inherit the mode specified via `defaults.mode` (see line number 3 and 4 of this config file).
-    browserName: "chrome"
-    src:
-      - "tests/*.test.ts" # test files glob
-    platformName: "mac 11.00" # Only relevant when running a test against the sauce cloud.
   - name: "Firefox in docker"
     mode: docker
     browserName: "firefox"
@@ -41,7 +36,7 @@ suites:
     browserName: "safari"
     src:
       - "tests/*.test.ts" # test files glob
-    devices:
+    simulators:
       - name: iPhone 12 Simulator
         platformName: iOS
         platformVersions:


### PR DESCRIPTION
When running the example I got this error.

`21:18:50 ERR failed to execute run command error="the 'devices' keyword in your config is now reserved for real devices, please use 'simulators' instead"`

This PR fixes that