### PR TITLE
[DEVX-1442] Comment out docker suite

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -25,11 +25,11 @@ suites:
     src:
       - "tests/*.test.js" # test files glob
     platformName: "mac 11.00" # Only relevant when running a test against the sauce cloud.
-  - name: "Firefox in docker"
-    mode: docker
-    browserName: "firefox"
-    src:
-      - "tests/*.test.js"
+  # - name: "Firefox in docker"
+  #   mode: docker
+  #   browserName: "firefox"
+  #   src:
+  #     - "tests/*.test.js"
   - name: "Firefox in sauce"
     mode: sauce
     browserName: "firefox"


### PR DESCRIPTION
I have gotten feedback from internal folks who have tried to use our Quickstart doc and when they run the test, it fails because they are not using Docker and don't have it set up and the Quickstart doesn't mention it. Since we are defaulting to running on Sauce for the QS, I think it is best to comment out the docker suite in the config.