### PR TITLE
Remove references to docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ jobs:
       CI_COMMIT_SHORT_SHA: $CIRCLE_SHA1
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
       - saucectl/saucectl-run
 
 workflows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Saucectl RUN Docker and Cloud
+      - name: Saucectl RUN
         uses: saucelabs/saucectl-run-action@v3
         with:
           concurrency: 10

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,7 @@
 image: alpine:3.9
 
 variables:
-    DOCKER_VERSION: 20.10.5
-    DOCKER_HOST: tcp://docker:2375
-    SAUCECTL_VERSION: 0.82.1
+    SAUCECTL_VERSION: 0.135.0
     SAUCE_USERNAME: ${SAUCE_USERNAME}
     SAUCE_ACCESS_KEY: ${SAUCE_ACCESS_KEY}
 
@@ -11,8 +9,6 @@ stages:
   - test
 
 .saucectl:
-  services:
-    - docker:${DOCKER_VERSION}-dind
   before_script:
     - apk add curl
     - curl -L -o saucectl.tar.gz https://github.com/saucelabs/saucectl/releases/download/v${SAUCECTL_VERSION}/saucectl_${SAUCECTL_VERSION}_linux_64-bit.tar.gz
@@ -21,7 +17,7 @@ stages:
 
 test:
   extends: .saucectl
-  image: docker:${DOCKER_VERSION}
+  image: ubuntu:latest
   stage: test
   script:
     - saucectl run -c .sauce/config.yml --ccy 10

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -1,7 +1,5 @@
 apiVersion: v1alpha
 kind: testcafe
-defaults:
-  mode: sauce
 sauce:
   region: us-west-1
   concurrency: 2 # Controls how many suites are executed at the same time.
@@ -11,32 +9,22 @@ sauce:
       - release team
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
-docker:
-  # Affects how test files are transferred to the docker container when using the docker mode.
-  fileTransfer: copy # Choose between mount|copy.
 testcafe:
   version: 2.3.1
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:
-  - name: "Chrome using global mode setting" # Since the suite doesn't specify the `mode`, it'll inherit the mode specified via `defaults.mode` (see line number 3 and 4 of this config file).
+  - name: "Chrome on macOS"
     browserName: "chrome"
     src:
       - "tests/*.test.js" # test files glob
-    platformName: "macOS 12" # Only relevant when running a test against the sauce cloud.
-  # - name: "Firefox in docker"
-  #   mode: docker
-  #   browserName: "firefox"
-  #   src:
-  #     - "tests/*.test.js"
-  - name: "Firefox in sauce"
-    mode: sauce
+    platformName: "macOS 12"
+  - name: "Firefox on Windows"
     browserName: "firefox"
     src:
       - "tests/*.test.js"
     platformName: "Windows 11"
   - name: iOS Test
-    mode: sauce
     browserName: "safari"
     src:
       - "tests/*.test.js" # test files glob
@@ -50,7 +38,7 @@ suites:
         platformVersions:
           - "14.3"
 
-# Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
+# Controls what artifacts to fetch when the suites have finished.
 artifacts:
   download:
     when: always

--- a/examples/typescript/.sauce/config.yml
+++ b/examples/typescript/.sauce/config.yml
@@ -1,7 +1,5 @@
 apiVersion: v1alpha
 kind: testcafe
-defaults:
-  mode: sauce
 sauce:
   region: us-west-1
   concurrency: 2 # Controls how many suites are executed at the same time.
@@ -11,20 +9,12 @@ sauce:
       - release team
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
-docker:
-  # Affects how test files are transferred to the docker container when using the docker mode.
-  fileTransfer: copy # Choose between mount|copy.
 testcafe:
   version: 2.3.1
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:
-  - name: "Firefox in docker"
-    mode: docker
-    browserName: "firefox"
-    src:
-      - "tests/*.test.ts"
-  - name: "Firefox in sauce"
+  - name: "Firefox on Windows"
     mode: sauce
     browserName: "firefox"
     src:
@@ -41,7 +31,7 @@ suites:
         platformVersions:
           - "14.3"
 
-# Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
+# Controls what artifacts to fetch when the suites have finished.
 artifacts:
   download:
     when: always


### PR DESCRIPTION
Removes all references to docker mode and parts that suggest we can execute somewhere else than on Sauce Labs Cloud.