### PR TITLE
Bump to testcafe@3.7.4

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
 testcafe:
-  version: 3.7.3
+  version: 3.7.4
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:

--- a/examples/browser_profile/.sauce/config.yml
+++ b/examples/browser_profile/.sauce/config.yml
@@ -8,7 +8,7 @@ sauce:
       - e2e-example
     build: $CI_COMMIT_SHORT_SHA
 testcafe:
-  version: 3.7.3
+  version: 3.7.4
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:

--- a/examples/react/.sauce/config.yml
+++ b/examples/react/.sauce/config.yml
@@ -9,7 +9,7 @@ sauce:
       - release team
       - other tag
 testcafe:
-  version: 3.7.3
+  version: 3.7.4
   configFile: .testcaferc.js
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "testcafe": "3.7.3",
+        "testcafe": "3.7.4",
         "testcafe-react-selectors": "^5.0.3"
       }
     },
@@ -4881,9 +4881,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-3.7.3.tgz",
-      "integrity": "sha512-PZfNGVXYX+KjKgHepsnPv4xgeA+PK9GiQF+OUl4R2tG8KBjqFgGP1sl5UOnFIIaL6ncbf5Erhpubt0VvsJlJ/w==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-3.7.4.tgz",
+      "integrity": "sha512-RADoEWAfGCQ1q08zr4kRQ+bEOhOiI3hmzF2s5dFv835ndERdE44V14DVqeOWGEFm0o+x6IYHyWhmQp0g9mz4ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "testcafe": "3.7.3",
+    "testcafe": "3.7.4",
     "testcafe-react-selectors": "^5.0.3"
   }
 }

--- a/examples/typescript/.sauce/config.yml
+++ b/examples/typescript/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
 testcafe:
-  version: 3.7.3
+  version: 3.7.4
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 suites:


### PR DESCRIPTION
## Summary
- Bump TestCafe from 3.7.3 to 3.7.4 across all config files and package.json

## Test plan
- [ ] Verify examples run successfully with TestCafe 3.7.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)