### PR TITLE
Add INT-31 TestCafe timeout bug reproduction

### DIFF
--- a/.sauce/config-int31-demo.yml
+++ b/.sauce/config-int31-demo.yml
@@ -1,0 +1,54 @@
+# INT-31 demo config — reproduces "Cannot establish one or more browser connections"
+# and shows the retries fix. Run with:
+#   saucectl run --config .sauce/config-int31-demo.yml
+apiVersion: v1alpha
+kind: testcafe
+sauce:
+  region: us-west-1
+  concurrency: 2 # Controls how many suites are executed at the same time.
+  retries: 1 # INT-31 fix: retry a failing suite once so a transient browser-connect flake is absorbed.
+  metadata:
+    tags:
+      - browser-connect
+    build: demo $CI_COMMIT_SHORT_SHA
+testcafe:
+  version: 3.7.4
+rootDir: ./
+suites:
+  # ---------------------------------------------------------------------------
+  # Suite A reproduces the EXACT error Cantina saw, on a real Sauce VM.
+  # browserInitTimeout is set deliberately low so the browser cannot connect back
+  # to TestCafe in time. saucectl passes this straight through (no floor in
+  # SetDefaults), so the run fails with "Cannot establish one or more browser
+  # connections" — the customer's exact error.
+  # NOTE: this is a *permanent* misconfig, not a transient flake, so the global
+  # `sauce.retries: 1` will retry it and it will fail again. That is expected and
+  # itself demonstrates that retries recover *transient* issues, not bad config.
+  - name: "DEMO force connect-failure (low browserInitTimeout)"
+    browserName: "chrome"
+    platformName: "macOS 13"
+    browserInitTimeout: 1000
+    src:
+      - "tests/example.test.js"
+
+  # Suite B is a healthy run with the fix (`sauce.retries: 1`) in place: a normal
+  # browserInitTimeout, so the browser connects and the test passes. If a real
+  # transient connect-flake occurred here, the retry would absorb it.
+  - name: "DEMO healthy run (retries enabled)"
+    browserName: "chrome"
+    platformName: "macOS 13"
+    browserInitTimeout: 120000
+    src:
+      - "tests/example.test.js"
+
+# Controls what artifacts to fetch when the suites have finished.
+artifacts:
+  download:
+    when: always
+    match:
+      - console.log
+    directory: ./artifacts/
+
+reporters:
+  spotlight: # Prints an overview of failed or otherwise interesting jobs.
+    enabled: true

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,4 @@ Here we have a list additional examples that cover more complicated setups.
 | ------- | ----------- |
 | [browser_profile](browser_profile) | Showcases how to run tests using testcafe, firefox with a custom browser profile. |
 | [typescript](typescript) | Showcases how to run tests using testcafe with typescript |
+| [timeout-repro](timeout-repro) | Reproduces a TestCafe bug where all timeouts are bypassed during page navigation stalls (INT-31) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,4 @@ Here we have a list additional examples that cover more complicated setups.
 | [browser_profile](browser_profile) | Showcases how to run tests using testcafe, firefox with a custom browser profile. |
 | [typescript](typescript) | Showcases how to run tests using testcafe with typescript |
 | [timeout-repro](timeout-repro) | Reproduces a TestCafe bug where all timeouts are bypassed during page navigation stalls (INT-31) |
+| [maxpath-repro](maxpath-repro) | Reproduces the Windows MAX_PATH=260 bundle-extraction failure (`Sauce Infrastructure Error`); root cause is in chef's `extract_archive` |

--- a/examples/maxpath-repro/.sauce/config.yml
+++ b/examples/maxpath-repro/.sauce/config.yml
@@ -1,0 +1,43 @@
+apiVersion: v1alpha
+kind: testcafe
+sauce:
+  region: us-west-1
+  concurrency: 1
+  metadata:
+    tags:
+      - maxpath-repro
+      - windows
+    build: "Windows MAX_PATH zip-extraction repro"
+testcafe:
+  version: 3.7.4
+# rootDir is bundled and shipped to the VM. It includes longpath-fixtures/, the
+# deeply-nested file whose path exceeds 260 chars once extracted on Windows.
+rootDir: ./
+suites:
+  # MUST be a Windows platform — the MAX_PATH=260 wall only exists on Windows.
+  # On macOS/Linux VMs chef extracts the same bundle with no problem, so the bug
+  # will NOT reproduce there. That contrast is itself part of the evidence.
+  - name: "maxpath-repro - Windows (expected: Sauce Infrastructure Error)"
+    browserName: "chrome"
+    platformName: "Windows 11"
+    src:
+      - "tests/*.test.js"
+
+  # Optional control suite: same bundle on macOS extracts fine and the test passes.
+  # Uncomment to demonstrate the bug is Windows-specific.
+  # - name: "maxpath-repro - macOS control (expected: PASS)"
+  #   browserName: "chrome"
+  #   platformName: "macOS 13"
+  #   src:
+  #     - "tests/*.test.js"
+
+artifacts:
+  download:
+    when: always
+    match:
+      - console.log
+    directory: ./artifacts/
+
+reporters:
+  spotlight:
+    enabled: true

--- a/examples/maxpath-repro/README.md
+++ b/examples/maxpath-repro/README.md
@@ -1,0 +1,82 @@
+# Windows MAX_PATH zip-extraction repro
+
+Reproduces the **`Sauce Infrastructure Error`** that occurs on **Windows** VMs when
+a bundled project contains a file whose path exceeds the legacy Windows
+`MAX_PATH = 260` character limit.
+
+This is **not** a TestCafe bug and **not** a saucectl bug — it is in the
+**`chef`** component that unpacks the project bundle on the VM. This example just
+triggers the customer-facing symptom end-to-end on a real Sauce Windows VM.
+
+## The Bug
+
+When you run `saucectl run`, your `rootDir` is zipped into
+`__project__/app.zip` and shipped to the VM. On the VM, `chef` extracts it to
+roughly:
+
+```
+D:\sauce-testcafe-runner\<version>\bundle\__project__\<your-files>
+```
+
+`chef.extract_archive()` uses CPython's `zipfile.extractall()` under **Python 2**,
+which does **no** `\\?\` extended-length path prefixing. Any extracted file whose
+absolute path exceeds 260 chars fails to write, and the job dies before the test
+runs:
+
+```
+error extracting zip archive D:\sauce-testcafe-runner\<ver>\bundle\__project__\app.zip
+into ...__project__. <type 'exceptions.IOError'>, [Errno 2] No such file or directory
+```
+
+Because chef runs on Python 2, the Windows 10 `LongPathsEnabled` registry /
+`longPathAware` manifest opt-in does **not** help — 260 is a hard wall.
+
+| Platform | Result |
+|----------|--------|
+| Windows  | ❌ extraction fails → `Sauce Infrastructure Error` (test never runs) |
+| macOS / Linux | ✅ no 260-char limit — same bundle extracts fine, test passes |
+
+## How It Works
+
+- `generate-longpath-fixture.sh` — creates `longpath-fixtures/<deeply-nested-dir>/<long-name>.txt`.
+  The path is ~268 chars on its own, so once combined with the VM's
+  `__project__` base prefix it is comfortably over 260.
+- `tests/smoke.test.js` — a trivial passing test. If it runs at all, extraction
+  succeeded. On Windows it never gets the chance.
+- `.sauce/config.yml` — targets **`Windows 11`** (required) with an optional,
+  commented-out macOS control suite.
+
+macOS/Linux have no 260-char path limit, so the fixture is created locally with
+no problem — the failure only surfaces on the Windows VM at extraction time.
+That asymmetry is the whole point of the repro.
+
+## Running
+
+```bash
+cd examples/maxpath-repro
+
+# 1. Materialize the long-path fixture (already committed, but safe to re-run)
+./generate-longpath-fixture.sh
+
+# 2. Run on Sauce (Windows)
+saucectl run
+```
+
+## Expected vs Actual
+
+- **Expected:** the bundle extracts and `smoke.test.js` passes.
+- **Actual (Windows):** the job fails with `Sauce Infrastructure Error` during
+  bundle extraction, before the test runs.
+
+To confirm it is Windows-specific, uncomment the macOS control suite in
+`.sauce/config.yml` and re-run — the same bundle passes there.
+
+## Root cause / fix
+
+Root cause and the implemented fix live in `chef`:
+prefix the extraction root with `\\?\` (absolute, backslash-separated, unicode
+under Py2) so member writes become extended-length and bypass MAX_PATH.
+
+Customer-side workarounds until the fix ships:
+- Shorten the longest path in your project.
+- Generate long-named fixtures **on the VM at runtime** instead of bundling them.

--- a/examples/maxpath-repro/generate-longpath-fixture.sh
+++ b/examples/maxpath-repro/generate-longpath-fixture.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Generates a fixture file whose path, relative to this example's rootDir, is long
+# enough that once saucectl bundles the project and chef extracts it on a Sauce
+# *Windows* VM, the file's absolute path exceeds the legacy MAX_PATH = 260 limit.
+#
+# On the VM the bundle is extracted to roughly:
+#   D:\sauce-testcafe-runner\<version>\bundle\__project__\<relative-path>
+# That base prefix is ~45 chars, so a relative path of ~230 chars reliably pushes
+# the absolute path past 260 and trips the chef `extract_archive` failure.
+#
+# macOS/Linux have no 260 limit, so this script creates the file with no trouble;
+# the failure only manifests on the Windows VM at extraction time. That asymmetry
+# is the whole point of the repro.
+#
+# Run from inside examples/maxpath-repro/ :  ./generate-longpath-fixture.sh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+ROOT="longpath-fixtures"
+# A single deeply-named directory + long filename. Segment names are padded so the
+# total relative path comfortably clears 230 characters.
+DIR="$ROOT/this-deeply-nested-directory-exists-only-to-push-the-bundled-file-path-well-beyond-the-windows-legacy-max-path-limit-of-260-chars-on-the-sauce-windows-vm"
+FILE="$DIR/ExtraLongName_fixture_document_that_reproduces_the_chef_extract_archive_maxpath_failure_Copy.txt"
+
+mkdir -p "$DIR"
+printf 'This file exists only so its bundled path exceeds Windows MAX_PATH (260).\n' > "$FILE"
+
+LEN=${#FILE}
+echo "Created fixture (relative path length = ${LEN} chars):"
+echo "  $FILE"
+if [ "$LEN" -lt 215 ]; then
+  echo "WARNING: relative path is only ${LEN} chars — may not exceed 260 on the VM." >&2
+fi

--- a/examples/maxpath-repro/longpath-fixtures/this-deeply-nested-directory-exists-only-to-push-the-bundled-file-path-well-beyond-the-windows-legacy-max-path-limit-of-260-chars-on-the-sauce-windows-vm/ExtraLongName_fixture_document_that_reproduces_the_chef_extract_archive_maxpath_failure_Copy.txt
+++ b/examples/maxpath-repro/longpath-fixtures/this-deeply-nested-directory-exists-only-to-push-the-bundled-file-path-well-beyond-the-windows-legacy-max-path-limit-of-260-chars-on-the-sauce-windows-vm/ExtraLongName_fixture_document_that_reproduces_the_chef_extract_archive_maxpath_failure_Copy.txt
@@ -1,0 +1,1 @@
+This file exists only so its bundled path exceeds Windows MAX_PATH (260).

--- a/examples/maxpath-repro/tests/smoke.test.js
+++ b/examples/maxpath-repro/tests/smoke.test.js
@@ -1,0 +1,42 @@
+// A trivial passing test. The point of this example is NOT the test logic — it is
+// what happens *before* the test runs: chef must extract the bundled project
+// (__project__/app.zip) on the Windows VM. When the bundle contains a file whose
+// path exceeds Windows MAX_PATH (260), extraction fails and the job dies with a
+// "Sauce Infrastructure Error" before this test ever executes.
+const fs = require('fs');
+const path = require('path');
+
+// Diagnostic: this test file runs in Node on the VM *after* extraction, so we can
+// walk the extracted bundle and log the real path lengths. This surfaces in the
+// TestCafe runner output (console.log asset / chef logs) — saucectl itself only
+// prints a "longestPathLength" number and never names the offending file.
+(function logLongestBundlePath() {
+  const projectRoot = path.resolve(__dirname, '..');
+  let longest = '';
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (path.relative(projectRoot, full).length > longest.length) {
+        longest = path.relative(projectRoot, full);
+      }
+    }
+  };
+  try {
+    walk(projectRoot);
+    const abs = path.join(projectRoot, longest);
+    console.log('[maxpath-repro] project root on VM: ' + projectRoot);
+    console.log('[maxpath-repro] longest file name:  ' + path.basename(longest) + ' (' + path.basename(longest).length + ' chars)');
+    console.log('[maxpath-repro] longest rel path:   ' + longest + ' (' + longest.length + ' chars)');
+    console.log('[maxpath-repro] longest abs path:   ' + abs + ' (' + abs.length + ' chars)');
+    console.log('[maxpath-repro] Windows MAX_PATH:   260 -> ' + (abs.length > 260 ? 'EXCEEDED' : 'within limit'));
+  } catch (e) {
+    console.log('[maxpath-repro] failed to scan bundle: ' + e.message);
+  }
+})();
+
+fixture`maxpath-repro`.page`https://example.com`;
+
+test('smoke - reached the test, so extraction succeeded', async (t) => {
+  await t.expect(true).ok();
+});

--- a/examples/timeout-repro/.sauce/config.yml
+++ b/examples/timeout-repro/.sauce/config.yml
@@ -1,0 +1,36 @@
+apiVersion: v1alpha
+kind: testcafe
+sauce:
+  region: us-west-1
+  concurrency: 1
+  metadata:
+    tags:
+      - INT-31
+      - timeout-repro
+    build: "INT-31 Timeout Reproduction"
+testcafe:
+  version: 3.7.2
+rootDir: ./
+suites:
+  - name: "timeout-repro - all timeouts set"
+    browserName: "chrome"
+    platformName: "macOS 14"
+    src:
+      - "tests/*.test.js"
+    # All 7 TestCafe timeouts are configured.
+    # None of them will fire when the page is stuck during navigation.
+    pageLoadTimeout: 15000       # 15 seconds
+    pageRequestTimeout: 15000    # 15 seconds
+    ajaxRequestTimeout: 15000    # 15 seconds
+    selectorTimeout: 10000       # 10 seconds
+    assertionTimeout: 10000      # 10 seconds
+    # testExecutionTimeout should be the ultimate safety net — but it doesn't work either.
+    testExecutionTimeout: 30000  # 30 seconds
+    timeout: "2m"                # suite timeout: 2 minutes (runner level)
+
+artifacts:
+  download:
+    when: always
+    match:
+      - console.log
+    directory: ./artifacts/

--- a/examples/timeout-repro/README.md
+++ b/examples/timeout-repro/README.md
@@ -1,0 +1,63 @@
+# INT-31: TestCafe Timeout Bug Reproduction
+
+Demonstrates a TestCafe bug where **all 7 timeout mechanisms are bypassed** when a page gets stuck during navigation.
+
+## The Bug
+
+When a page has a parser-blocking resource that never finishes loading (e.g., a `<script>` tag whose server never responds), `DOMContentLoaded` never fires. TestCafe's driver command queue waits for the browser to signal "page ready" with **no timeout on that wait**. This freezes all configured timeouts:
+
+| Timeout | Why It Doesn't Fire |
+|---------|-------------------|
+| `pageRequestTimeout` | Page HTML was already received |
+| `pageLoadTimeout` | Countdown starts after DOMContentLoaded — never reached |
+| `ajaxRequestTimeout` | Only covers XHR/fetch, not page-level resources |
+| `selectorTimeout` | TestCafe hasn't reached the next test action |
+| `assertionTimeout` | Same as selectorTimeout |
+| `testExecutionTimeout` | Frozen waiting for page readiness |
+| `runExecutionTimeout` | Same |
+
+## How It Works
+
+- `server.js` — HTTP server with three endpoints:
+  - `/login` — Normal page that loads fine
+  - `/dashboard` — Page with a `<script src="/never-loads">` that blocks the HTML parser
+  - `/never-loads` — Accepts the connection but never sends a response body
+
+- `tests/timeout-hang.test.js` — TestCafe test that logs in, navigates to `/dashboard`, and hangs
+
+## Running Locally
+
+### 1. Start the test server
+
+```bash
+node server.js
+```
+
+### 2. Run with TestCafe directly
+
+```bash
+npx testcafe chrome:headless tests/timeout-hang.test.js \
+  --page-load-timeout 15000 \
+  --page-request-timeout 15000 \
+  --ajax-request-timeout 15000 \
+  --selector-timeout 10000 \
+  --assertion-timeout 10000
+```
+
+The test will hang indefinitely despite all timeouts being set to 15 seconds.
+
+### 3. Run with saucectl (on Sauce Labs)
+
+```bash
+cd examples/timeout-repro
+saucectl run
+```
+
+The `.sauce/config.yml` has `testExecutionTimeout: 30000` (30s) and all other timeouts set to 15s. The test will hang past all of them.
+
+## Expected vs Actual
+
+- **Expected:** `testExecutionTimeout` (30s) or `pageLoadTimeout` (15s) should terminate the test
+- **Actual:** Test hangs indefinitely — all timeouts are bypassed
+
+This confirms the issue is in TestCafe's driver command queue, not in Sauce Labs infrastructure.

--- a/examples/timeout-repro/server.js
+++ b/examples/timeout-repro/server.js
@@ -1,0 +1,71 @@
+const http = require('http');
+
+const PORT = 8899;
+
+const loginPage = `
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+  <h1>Login Page</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" />
+    <input type="password" id="password" placeholder="Password" />
+    <button type="submit" id="loginBtn">Login</button>
+  </form>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      window.location.href = '/dashboard';
+    });
+  </script>
+</body>
+</html>
+`;
+
+// This page has a parser-blocking script that never finishes loading.
+// The browser receives the HTTP response (so pageRequestTimeout is satisfied),
+// but the <script src="/never-loads"> blocks the HTML parser.
+// DOMContentLoaded will NEVER fire because the parser is waiting for the script.
+// This means pageLoadTimeout never starts its countdown.
+const dashboardPage = `
+<!DOCTYPE html>
+<html>
+<head><title>Dashboard</title></head>
+<body>
+  <h1>Loading Dashboard...</h1>
+  <script src="/never-loads"></script>
+  <div id="dashboard-content">Welcome to the dashboard</div>
+</body>
+</html>
+`;
+
+const server = http.createServer((req, res) => {
+  console.log(`[${new Date().toISOString()}] ${req.method} ${req.url}`);
+
+  if (req.url === '/' || req.url === '/login') {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(loginPage);
+  } else if (req.url === '/dashboard') {
+    // Send the full HTML response immediately — pageRequestTimeout is satisfied
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(dashboardPage);
+  } else if (req.url === '/never-loads') {
+    // This endpoint never responds — the browser's script request hangs forever.
+    // The HTML parser is blocked waiting for this script.
+    // DOMContentLoaded will never fire.
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
+    // Intentionally never call res.end() — connection stays open
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Test server running at http://localhost:${PORT}`);
+  console.log('Routes:');
+  console.log('  /login     - Normal login page (loads fine)');
+  console.log('  /dashboard - Page with blocking script (DOMContentLoaded never fires)');
+  console.log('  /never-loads - Script endpoint that never responds');
+});

--- a/examples/timeout-repro/tests/timeout-hang.test.js
+++ b/examples/timeout-repro/tests/timeout-hang.test.js
@@ -1,0 +1,160 @@
+import { Selector } from 'testcafe';
+import http from 'http';
+
+// ============================================================================
+// INT-31: TestCafe Timeout Bug Reproduction
+//
+// This test proves that ALL TestCafe timeout mechanisms are bypassed when a
+// page gets stuck during navigation due to a parser-blocking resource.
+//
+// Configuration (set via CLI or .sauce/config.yml):
+//   pageLoadTimeout:      15,000 ms (15s)
+//   pageRequestTimeout:   15,000 ms (15s)
+//   ajaxRequestTimeout:   15,000 ms (15s)
+//   selectorTimeout:      10,000 ms (10s)
+//   assertionTimeout:     10,000 ms (10s)
+//   testExecutionTimeout: 30,000 ms (30s)
+//
+// Expected: Test should fail within 30s (testExecutionTimeout)
+// Actual:   Test hangs indefinitely — none of the above timeouts fire
+//
+// The test is only terminated by the suite-level timeout (2 min), which is
+// NOT a TestCafe timeout — it's the runner's wrapper timeout.
+// ============================================================================
+
+const PORT = 8899;
+
+const loginPage = `
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+  <h1>Login Page</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" />
+    <input type="password" id="password" placeholder="Password" />
+    <button type="submit" id="loginBtn">Login</button>
+  </form>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      window.location.href = '/dashboard';
+    });
+  </script>
+</body>
+</html>
+`;
+
+// The dashboard page has a parser-blocking <script> that never finishes loading.
+// The browser receives the full HTML (so pageRequestTimeout is satisfied),
+// but the HTML parser is blocked waiting for /never-loads to respond.
+// DOMContentLoaded will NEVER fire because the parser can't finish.
+// TestCafe waits for DOMContentLoaded to signal "page ready" — with no timeout.
+const dashboardPage = `
+<!DOCTYPE html>
+<html>
+<head><title>Dashboard</title></head>
+<body>
+  <h1>Loading Dashboard...</h1>
+  <script src="/never-loads"></script>
+  <div id="dashboard-content">Welcome to the dashboard</div>
+</body>
+</html>
+`;
+
+let server;
+
+function startServer() {
+  return new Promise((resolve) => {
+    server = http.createServer((req, res) => {
+      console.log(`[SERVER] [${new Date().toISOString()}] ${req.method} ${req.url}`);
+
+      if (req.url === '/' || req.url === '/login') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(loginPage);
+      } else if (req.url === '/dashboard') {
+        // Full HTML sent immediately — pageRequestTimeout is satisfied
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(dashboardPage);
+      } else if (req.url === '/never-loads') {
+        // This endpoint accepts the connection but NEVER sends a response body.
+        // The browser's script request hangs forever.
+        // The HTML parser is blocked waiting for this script to load.
+        // DOMContentLoaded will never fire.
+        console.log('[SERVER] /never-loads hit — this request will hang forever (simulating a stalled resource)');
+        res.writeHead(200, { 'Content-Type': 'application/javascript' });
+        // Intentionally never call res.end()
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+    });
+    server.listen(PORT, () => {
+      console.log(`[SERVER] Test server running at http://localhost:${PORT}`);
+      console.log('[SERVER] /login      — Normal page (loads fine)');
+      console.log('[SERVER] /dashboard  — Page with parser-blocking <script src="/never-loads">');
+      console.log('[SERVER] /never-loads — Accepts connection, never responds (simulates stalled resource)');
+      resolve();
+    });
+  });
+}
+
+function stopServer() {
+  return new Promise((resolve) => {
+    if (server) {
+      server.close(() => resolve());
+    } else {
+      resolve();
+    }
+  });
+}
+
+fixture('INT-31 Timeout Reproduction')
+  .page(`http://localhost:${PORT}/login`)
+  .before(async () => {
+    await startServer();
+  })
+  .after(async () => {
+    await stopServer();
+  });
+
+test('TestCafe timeouts are bypassed when page navigation stalls', async (t) => {
+  const startTime = Date.now();
+  console.log('');
+  console.log('========================================================');
+  console.log('  INT-31: TestCafe Timeout Bug Reproduction');
+  console.log('========================================================');
+  console.log(`  Configured timeouts:`);
+  console.log(`    pageLoadTimeout:      15s`);
+  console.log(`    pageRequestTimeout:   15s`);
+  console.log(`    ajaxRequestTimeout:   15s`);
+  console.log(`    testExecutionTimeout: 30s`);
+  console.log(`  Expected: test should fail within 30s`);
+  console.log(`  Actual:   test will hang until suite timeout (2 min)`);
+  console.log('========================================================');
+  console.log('');
+  console.log(`[TEST] [${new Date().toISOString()}] Step 1: Login page loaded successfully`);
+
+  // Step 1: Login page loads fine — no issues here
+  await t.typeText('#username', 'testuser');
+  await t.typeText('#password', 'password123');
+  console.log(`[TEST] [${new Date().toISOString()}] Step 2: Filled login form, clicking submit...`);
+  console.log(`[TEST] This will navigate to /dashboard which has a parser-blocking script`);
+
+  // Step 2: Click login — navigates to /dashboard
+  // The dashboard HTML is served immediately (pageRequestTimeout: satisfied)
+  // But it contains <script src="/never-loads"> which blocks the HTML parser
+  // DOMContentLoaded never fires → TestCafe never gets the "page ready" signal
+  // All TestCafe timeouts freeze at this point
+  await t.click('#loginBtn');
+
+  // If we reach this line, the bug is fixed (we won't reach it)
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`[TEST] [${new Date().toISOString()}] Navigation completed after ${elapsed}s`);
+  console.log(`[TEST] If you see this, the TestCafe bug has been fixed!`);
+
+  // Step 3: This will never execute — TestCafe is stuck waiting for "page ready"
+  const dashboard = Selector('#dashboard-content');
+  await t.expect(dashboard.exists).ok('Dashboard content should be visible');
+  console.log(`[TEST] Dashboard loaded — THIS LINE SHOULD NEVER PRINT`);
+});


### PR DESCRIPTION
## Summary

- Adds a self-contained reproduction example under `examples/timeout-repro/` that demonstrates a TestCafe bug where **all 7 timeout mechanisms are bypassed** when a page gets stuck during navigation due to a parser-blocking resource.
- The test starts an HTTP server inside the fixture (no tunnel needed) that serves a page with a `<script>` tag whose endpoint never responds, blocking the HTML parser so `DOMContentLoaded` never fires.
- TestCafe's driver command queue waits for "page ready" indefinitely with no timeout on that wait, freezing all configured timeouts.

## Evidence

**Sauce Labs test:** https://app.saucelabs.com/tests/b6839d172f00480ca99667411b2fa2e6

Config used:
| Timeout | Value | Fired? |
|---------|-------|--------|
| `pageLoadTimeout` | 15s | No |
| `pageRequestTimeout` | 15s | No |
| `ajaxRequestTimeout` | 15s | No |
| `selectorTimeout` | 10s | No |
| `assertionTimeout` | 10s | No |
| `testExecutionTimeout` | 30s | No |
| Suite timeout (runner) | 2m | **Yes** (only thing that stopped it) |

Test ran for **2m5s** — well past every TestCafe timeout. Only terminated by the runner's suite timeout.

## How to reproduce

**On Sauce Labs:**
```bash
cd examples/timeout-repro
saucectl run
```

**Locally:**
```bash
cd examples/timeout-repro
node server.js  # in one terminal
npx testcafe chrome:headless tests/timeout-hang.test.js --page-load-timeout 15000 --test-execution-timeout 30000
```

The test will hang indefinitely despite `testExecutionTimeout` being set to 30s.

## Test plan

- [x] Verified locally — test hangs past all configured timeouts
- [x] Verified on Sauce Labs — test ran 2m5s, only stopped by suite timeout
- [x] No external dependencies — server runs inside the test fixture