### PR TITLE
INT-246: Add macOS 26 ARM example suite

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -43,6 +43,12 @@ suites:
       - "tests/*.test.js" # test files glob
     platformName: "macOS 15"
     armRequired: true
+  - name: Chrome on macOS 26 ARM
+    browserName: chrome
+    src:
+      - "tests/*.test.js" # test files glob
+    platformName: "macOS 26"
+    armRequired: true
 
 
 # Controls what artifacts to fetch when the suites have finished.


### PR DESCRIPTION
Adds a macOS 26 ARM example suite, mirroring the existing macOS suites. macOS 26 is now live and validated on prod for TestCafe (verified end-to-end via devx-e2e). Part of INT-246 (macOS 26 enablement).